### PR TITLE
Library: Fix legend spacing

### DIFF
--- a/_library_formats/AdLibMIDI.html
+++ b/_library_formats/AdLibMIDI.html
@@ -1,6 +1,6 @@
 ---
 filename: AdLibMIDI.zip
-flags: "AD PMS"
+flags: "A D PMS"
 extension: .MUS
 desc: AdLib MIDI Format
 ---

--- a/_library_formats/GodOfThunder.html
+++ b/_library_formats/GodOfThunder.html
@@ -1,6 +1,6 @@
 ---
 filename: GodOfThunder.zip
-flags: "AD  M "
+flags: "A D  M "
 extension: .GOT
 desc: God Of Thunder Music
 ---

--- a/_library_formats/IMPlay.html
+++ b/_library_formats/IMPlay.html
@@ -1,6 +1,6 @@
 ---
 filename: IMPlay.zip
-flags: "AD PM "
+flags: "A D PM "
 extension: .IMS
 desc: IMPlay Song Format
 ---

--- a/_library_formats/MIDIPlay.html
+++ b/_library_formats/MIDIPlay.html
@@ -1,6 +1,6 @@
 ---
 filename: MIDIPlay.zip
-flags: "AD PMS"
+flags: "A D PMS"
 extension: .MDI
 desc: AdLib MIDIPlay Format
 ---

--- a/_library_formats/MacsOpera.html
+++ b/_library_formats/MacsOpera.html
@@ -1,6 +1,6 @@
 ---
 filename: MacsOpera.zip
-flags: "AD  M "
+flags: "A D  M "
 extension: .CMF
 desc: MacsOpera
 ---


### PR DESCRIPTION
According to the `A DEPMS` legend, didn't noticed it at first